### PR TITLE
fix: 修正呼叫 SetRichPresence() 方法會發生例外的問題

### DIFF
--- a/App.config
+++ b/App.config
@@ -156,7 +156,7 @@
         <value>50</value>
       </setting>
       <setting name="LibMpvArchiveFileName" serializeAs="String">
-        <value>mpv-dev-x86_64-20210725-git-e2109b6.7z</value>
+        <value>mpv-dev-x86_64-20211212-git-0e76372.7z</value>
       </setting>
       <setting name="Aria2Version" serializeAs="String">
         <value>1.36.0</value>

--- a/Common/Utils/DiscordRichPresenceUtil.cs
+++ b/Common/Utils/DiscordRichPresenceUtil.cs
@@ -184,6 +184,18 @@ internal class DiscordRichPresenceUtil
                 !string.IsNullOrEmpty(state) ||
                 assets != null)
             {
+                int magicNum = 43, maxLength = 40;
+
+                if (details.Length > magicNum)
+                {
+                    details = $"{details[..maxLength]}...";
+                }
+
+                if (state.Length > magicNum)
+                {
+                    state = $"{state[..maxLength]}...";
+                }
+
                 _GlobalDRClient?.SetPresence(new()
                 {
                     Details = details,

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -11,7 +11,7 @@
 	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 	<ApplicationIcon>Resources\app_icon.ico</ApplicationIcon>
 	<DebugType>embedded</DebugType>
-	<Version>1.0.0</Version>
+	<Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -604,7 +604,7 @@ namespace CustomToolbox.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("mpv-dev-x86_64-20210725-git-e2109b6.7z")]
+        [global::System.Configuration.DefaultSettingValueAttribute("mpv-dev-x86_64-20211212-git-0e76372.7z")]
         public string LibMpvArchiveFileName {
             get {
                 return ((string)(this["LibMpvArchiveFileName"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -159,7 +159,7 @@
       <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="LibMpvArchiveFileName" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">mpv-dev-x86_64-20210725-git-e2109b6.7z</Value>
+      <Value Profile="(Default)">mpv-dev-x86_64-20211212-git-0e76372.7z</Value>
     </Setting>
     <Setting Name="Aria2Version" Type="System.String" Scope="Application">
       <Value Profile="(Default)">1.36.0</Value>

--- a/WMain.Methods.cs
+++ b/WMain.Methods.cs
@@ -201,11 +201,11 @@ public partial class WMain
 
                             // 載入網路資源。
                             InitNetResurce();
-
-                            // 檢查應用程式是否有新版本。
-                            CheckAppVersion();
                         });
                     }));
+
+                // 檢查應用程式是否有新版本。
+                CheckAppVersion();
             }));
         }
         catch (Exception ex)


### PR DESCRIPTION
1. 在 SetRichPresence() 方法內加入判斷 details 以及 state 等變數長度的機制，盡量將內容縮限於 128 byte 以內。
2. 變更下載的 libmpv 的檔案名稱。
3. 變更預設執行  CheckAppVersion() 方法的位置，用以避免發生例外。