### PR TITLE
fix: 修正匯出時間標記文字檔案時網址資訊會出錯的問題

### DIFF
--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -11,7 +11,7 @@
 	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 	<ApplicationIcon>Resources\app_icon.ico</ApplicationIcon>
 	<DebugType>embedded</DebugType>
-	<Version>1.0.2</Version>
+	<Version>1.0.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/WMain.Events.cs
+++ b/WMain.Events.cs
@@ -294,8 +294,6 @@ public partial class WMain : Window
                     case 5:
                         // ※輸出的備註內容需保持正體中文。 
 
-
-
                         var grpClipDataSet = dataSource.GroupBy(n => n.VideoUrlOrID);
 
                         foreach (var grpClipData in grpClipDataSet)
@@ -306,7 +304,17 @@ public partial class WMain : Window
                             {
                                 if (countIndex2 == 0)
                                 {
-                                    outputContent += VariableSet.TimestampHeaderTemplate.Replace("{VideoID}", grpClipData.Key);
+                                    if (grpClipData.Key?.StartsWith("http") == true)
+                                    {
+                                        outputContent += VariableSet.TimestampHeaderTemplate
+                                            .Replace("https://www.youtube.com/watch?v={VideoID}", grpClipData.Key);
+                                    }
+                                    else
+                                    {
+                                        outputContent += VariableSet.TimestampHeaderTemplate
+                                            .Replace("{VideoID}", grpClipData.Key);
+                                    }
+
                                     outputContent += $"{VariableSet.Timestamp.StartReadingToken}{Environment.NewLine}";
                                 }
 


### PR DESCRIPTION
加入開頭是否為 http 的判斷，並針對判斷結果使用不同的替換字串內容。