### PR TITLE
v1.0.11

### DIFF
--- a/App.config
+++ b/App.config
@@ -59,7 +59,7 @@
       <value>False</value>
     </setting>
     <setting name="UserAgent" serializeAs="String">
-      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36</value>
+      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36</value>
     </setting>
     <setting name="OpenCCS2TWP" serializeAs="String">
       <value>False</value>
@@ -165,7 +165,7 @@
         <value>1.36.0</value>
       </setting>
       <setting name="SecChUa" serializeAs="String">
-        <value>"Google Chrome";v="111", "Not A(Brand";v="8", "Chromium";v="111"</value>
+        <value>"Chromium";v="112", "Google Chrome";v="112", "Not:A-Brand";v="99"</value>
       </setting>
       <setting name="SecChUaMobile" serializeAs="String">
         <value>?0</value>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # 自定義工具箱更新日誌
 
+- 1.0.11
+  1. 更新預設的使用者代理字串。（Google Chrome v112）
+  2. 變更查詢使用者代理字串的網址，改為使用 WhatIsMyBrowser.com 網站。
+  3. 更新 H.NotifyIcon.Wpf 函式庫至 2.0.108 版。
+  4. 更新 Microsoft.Playwright 函式庫至1.32.0 版。
+  5. 更新 YoutubeDLSharp 函式庫至 1.0.0-beta6 版。
 - 1.0.10
   1. 更新 Downloader 函式庫至 3.0.4 版。
   2. 更新 H.NotifyIcon.Wpf 函式庫至 2.0.99 版。

--- a/Common/Sets/UrlSet.cs
+++ b/Common/Sets/UrlSet.cs
@@ -6,9 +6,14 @@
 internal class UrlSet
 {
     /// <summary>
+    /// 查詢使用者代理字串的網址（舊）
+    /// </summary>
+    public static readonly string OldQueryUserAgentUrl = "https://www.google.com/search?q=My+User+Agent";
+
+    /// <summary>
     /// 查詢使用者代理字串的網址
     /// </summary>
-    public static readonly string QueryUserAgentUrl = "https://www.google.com/search?q=My+User+Agent";
+    public static readonly string QueryUserAgentUrl = "https://www.whatismybrowser.com/detect/what-is-my-user-agent";
 
     /// <summary>
     /// AppVersion.json 檔案的網址

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -11,7 +11,7 @@
 	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 	<ApplicationIcon>Resources\app_icon.ico</ApplicationIcon>
 	<DebugType>embedded</DebugType>
-	<Version>1.0.10</Version>
+	<Version>1.0.11</Version>
   </PropertyGroup>
 
   <ItemGroup>
@@ -19,18 +19,18 @@
     <PackageReference Include="ConsoleTableExt" Version="3.2.0" />
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
     <PackageReference Include="Downloader" Version="3.0.4" />
-    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.99" />
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.31.1" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.32.0" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <PackageReference Include="Mpv.NET" Version="1.2.0" />
     <PackageReference Include="OpenCCNET" Version="1.0.2" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
     <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
-    <PackageReference Include="YoutubeDLSharp" Version="1.0.0-beta4" />
+    <PackageReference Include="YoutubeDLSharp" Version="1.0.0-beta6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -235,7 +235,7 @@ namespace CustomToolbox.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/111.0.0.0 Safari/537.36")]
+            "Chrome/112.0.0.0 Safari/537.36")]
         public string UserAgent {
             get {
                 return ((string)(this["UserAgent"]));
@@ -622,7 +622,7 @@ namespace CustomToolbox.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\"Google Chrome\";v=\"111\", \"Not A(Brand\";v=\"8\", \"Chromium\";v=\"111\"")]
+        [global::System.Configuration.DefaultSettingValueAttribute("\"Chromium\";v=\"112\", \"Google Chrome\";v=\"112\", \"Not:A-Brand\";v=\"99\"")]
         public string SecChUa {
             get {
                 return ((string)(this["SecChUa"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -57,7 +57,7 @@
       <Value Profile="(Default)">10</Value>
     </Setting>
     <Setting Name="UserAgent" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/111.0.0.0 Safari/537.36</Value>
+      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/112.0.0.0 Safari/537.36</Value>
     </Setting>
     <Setting Name="RDGContentRow1Height" Type="System.Windows.GridLength" Scope="User">
       <Value Profile="(Default)">2*</Value>
@@ -165,7 +165,7 @@
       <Value Profile="(Default)">1.36.0</Value>
     </Setting>
     <Setting Name="SecChUa" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">"Google Chrome";v="111", "Not A(Brand";v="8", "Chromium";v="111"</Value>
+      <Value Profile="(Default)">"Chromium";v="112", "Google Chrome";v="112", "Not:A-Brand";v="99"</Value>
     </Setting>
     <Setting Name="SecChUaMobile" Type="System.String" Scope="Application">
       <Value Profile="(Default)">?0</Value>


### PR DESCRIPTION
1. 更新預設的使用者代理字串。（Google Chrome v112）
2. 變更查詢使用者代理字串的網址，改為使用 WhatIsMyBrowser.com 網站。
3. 更新 H.NotifyIcon.Wpf 函式庫至 2.0.108 版。
4. 更新 Microsoft.Playwright 函式庫至1.32.0 版。
5. 更新 YoutubeDLSharp 函式庫至 1.0.0-beta6 版。
6. 更新 CHANGELOG.md 的內容。