### PR TITLE
fix: 修正短片列表時間欄位不可以直接輸入時間格式字串的問題

### DIFF
--- a/Common/Converters/TimeSpanConverter.cs
+++ b/Common/Converters/TimeSpanConverter.cs
@@ -18,15 +18,25 @@ class TimeSpanConverter : IValueConverter
         {
             return TimeSpan.FromSeconds(result1);
         }
-        else if (value is string ||
-            value is int ||
+        else if (value is string actualString)
+        {
+            if (TimeSpan.TryParse(actualString, out TimeSpan result2))
+            {
+                return result2;
+            }
+            else
+            {
+                TimeSpan.FromSeconds(0);
+            }
+        }
+        else if (value is int ||
             value is long ||
             value is float ||
             value is decimal)
         {
-            if (double.TryParse(value.ToString(), out double result2))
+            if (double.TryParse(value.ToString(), out double result3))
             {
-                return TimeSpan.FromSeconds(result2);
+                return TimeSpan.FromSeconds(result3);
             }
         }
 
@@ -43,15 +53,25 @@ class TimeSpanConverter : IValueConverter
         {
             return TimeSpan.FromSeconds(result1);
         }
-        else if (value is string ||
-            value is int ||
+        else if (value is string actualString)
+        {
+            if (TimeSpan.TryParse(actualString, out TimeSpan result2))
+            {
+                return result2;
+            }
+            else
+            {
+                TimeSpan.FromSeconds(0);
+            }
+        }
+        else if (value is int ||
             value is long ||
             value is float ||
             value is decimal)
         {
-            if (double.TryParse(value.ToString(), out double result2))
+            if (double.TryParse(value.ToString(), out double result3))
             {
-                return TimeSpan.FromSeconds(result2);
+                return TimeSpan.FromSeconds(result3);
             }
         }
 

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -11,7 +11,7 @@
 	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 	<ApplicationIcon>Resources\app_icon.ico</ApplicationIcon>
 	<DebugType>embedded</DebugType>
-	<Version>1.0.12</Version>
+	<Version>1.0.13</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
調整 TimeSpanConverter.cs 內針對 string 格式資料的處理方式。