### PR TITLE
v1.0.15

### DIFF
--- a/App.config
+++ b/App.config
@@ -59,7 +59,7 @@
       <value>False</value>
     </setting>
     <setting name="UserAgent" serializeAs="String">
-      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36</value>
+      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</value>
     </setting>
     <setting name="OpenCCS2TWP" serializeAs="String">
       <value>False</value>
@@ -144,7 +144,7 @@
         <value>30000</value>
       </setting>
       <setting name="PlaywrightSleepMs" serializeAs="String">
-        <value>1000</value>
+        <value>2000</value>
       </setting>
       <setting name="PlaywrightDevSleepMs" serializeAs="String">
         <value>120000</value>
@@ -165,7 +165,7 @@
         <value>1.36.0</value>
       </setting>
       <setting name="SecChUa" serializeAs="String">
-        <value>"Google Chrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"</value>
+        <value>"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"</value>
       </setting>
       <setting name="SecChUaMobile" serializeAs="String">
         <value>?0</value>

--- a/App.config
+++ b/App.config
@@ -59,7 +59,7 @@
       <value>False</value>
     </setting>
     <setting name="UserAgent" serializeAs="String">
-      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</value>
+      <value>Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36</value>
     </setting>
     <setting name="OpenCCS2TWP" serializeAs="String">
       <value>False</value>
@@ -165,7 +165,7 @@
         <value>1.36.0</value>
       </setting>
       <setting name="SecChUa" serializeAs="String">
-        <value>"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"</value>
+        <value>"Not/A)Brand";v="99.0.0.0", "Google Chrome";v="115.0.5790.99", "Chromium";v="115.0.5790.99"</value>
       </setting>
       <setting name="SecChUaMobile" serializeAs="String">
         <value>?0</value>

--- a/BilibiliApi/Funcs/AuthFunction.cs
+++ b/BilibiliApi/Funcs/AuthFunction.cs
@@ -1,0 +1,96 @@
+﻿using System.Net.Http;
+using System.Security.Cryptography;
+using System.Text.Json.Nodes;
+using System.Text;
+
+namespace CustomToolbox.BilibiliApi.Funcs;
+
+/// <summary>
+/// 驗證函式
+/// <para>來源：https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/misc/sign/wbi.md</para>
+/// </summary>
+public class AuthFunction
+{
+    private static readonly int[] MixinKeyEncTab =
+    {
+        46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39,
+        12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 54, 21, 56, 59, 6, 63,
+        57, 62, 11, 36, 20, 34, 44, 52
+    };
+
+    /// <summary>
+    /// 對 imgKey 和 subKey 進行字元順序打亂編碼
+    /// </summary>
+    /// <param name="orig"></param>
+    /// <returns>字串</returns>
+    private static string GetMixinKey(string orig)
+    {
+        return MixinKeyEncTab.Aggregate("", (s, i) => s + orig[i])[..32];
+    }
+
+    /// <summary>
+    /// 
+    /// </summary>
+    /// <param name="parameters"></param>
+    /// <param name="imgKey"></param>
+    /// <param name="subKey"></param>
+    /// <returns>Dictionary&lt;string, string&gt;</returns>
+    private static Dictionary<string, string> EncWbi(
+        Dictionary<string, string> parameters,
+        string imgKey,
+        string subKey)
+    {
+        string mixinKey = GetMixinKey(imgKey + subKey);
+        string currTime = DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
+
+        // 增加 wts 的內容。
+        parameters["wts"] = currTime;
+
+        // 依照 key 重排參數。
+        parameters = parameters.OrderBy(p => p.Key).ToDictionary(p => p.Key, p => p.Value);
+
+        // 過濾 value 中的 "!'()*" 字元。
+        parameters = parameters.ToDictionary(
+            kvp => kvp.Key,
+            kvp => new string(kvp.Value.Where(chr => !"!'()*".Contains(chr)).ToArray())
+        );
+
+        // 序列化參數。
+        string query = new FormUrlEncodedContent(parameters).ReadAsStringAsync().Result;
+
+        // 計算 w_rid。
+        byte[] hashBytes = MD5.HashData(Encoding.UTF8.GetBytes(query + mixinKey));
+
+        string wbiSign = BitConverter.ToString(hashBytes).Replace("-", "").ToLower();
+
+        parameters["w_rid"] = wbiSign;
+
+        return parameters;
+    }
+
+    /// <summary>
+    /// 獲取最新的 img_key 和 sub_key
+    /// </summary>
+    /// <param name="httpClient">HttpClient</param>
+    /// <returns>Task&lt;(string, string)&gt;</returns>
+    private static async Task<(string, string)> GetWbiKeys(HttpClient httpClient)
+    {
+        HttpResponseMessage responseMessage = await httpClient.SendAsync(new HttpRequestMessage
+        {
+            Method = HttpMethod.Get,
+            RequestUri = new Uri("https://api.bilibili.com/x/web-interface/nav"),
+        });
+
+        JsonNode response = JsonNode.Parse(await responseMessage.Content.ReadAsStringAsync())!;
+
+        string imgUrl = (string)response["data"]!["wbi_img"]!["img_url"]!;
+
+        imgUrl = imgUrl.Split("/")[^1].Split(".")[0];
+
+        string subUrl = (string)response["data"]!["wbi_img"]!["sub_url"]!;
+
+        subUrl = subUrl.Split("/")[^1].Split(".")[0];
+
+        return (imgUrl, subUrl);
+    }
+}

--- a/BilibiliApi/Funcs/AuthFunction.cs
+++ b/BilibiliApi/Funcs/AuthFunction.cs
@@ -8,13 +8,15 @@ namespace CustomToolbox.BilibiliApi.Funcs;
 /// <summary>
 /// 驗證函式
 /// <para>來源：https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/docs/misc/sign/wbi.md</para>
+/// <para>原授權：CC BY-NC 4.0</para>
+/// <para>CC BY-NC 4.0：https://github.com/SocialSisterYi/bilibili-API-collect/blob/master/LICENSE</para>
 /// </summary>
 public class AuthFunction
 {
     /// <summary>
-    /// 混合鍵值加密表
+    /// 混合鍵值編碼表
     /// </summary>
-    private static readonly int[] MixinKeyEncTab =
+    private static readonly int[] MixinKeyEncodeTable =
     {
         46, 47, 18, 2, 53, 8, 23, 32, 15, 50, 10, 31, 58, 3, 45, 35, 27, 43, 5, 49, 33, 9, 42, 19, 29, 28, 14, 39,
         12, 38, 41, 13, 37, 48, 7, 16, 24, 55, 40, 61, 26, 17, 0, 1, 60, 51, 30, 4, 22, 25, 54, 21, 56, 59, 6, 63,
@@ -29,28 +31,27 @@ public class AuthFunction
     /// <returns>字串</returns>
     private static string GetMixinKey(string value)
     {
-        return MixinKeyEncTab.Aggregate(string.Empty, (stringValue, index) => stringValue + value[index])[..32];
+        return MixinKeyEncodeTable.Aggregate(string.Empty, (stringValue, index) => stringValue + value[index])[..32];
     }
 
     /// <summary>
-    /// 加密 Wbi
+    /// 編碼 Wbi
     /// </summary>
-    /// <param name="parameters">Dictionary&lt;string, string&gt;</param>
+    /// <param name="parameters">Dictionary&lt;string, string&gt;，查詢字串參數</param>
     /// <param name="imgKey">字串，imgKey</param>
     /// <param name="subKey">字串，subKey</param>
-    /// <returns>Dictionary&lt;string, string&gt;</returns>
-    private static Dictionary<string, string> EncWbi(
+    /// <returns>Task&lt;&lt;string, string&gt;&gt;</returns>
+    private async static Task<Dictionary<string, string>> EncodeWbi(
         Dictionary<string, string> parameters,
         string imgKey,
         string subKey)
     {
         string mixinKey = GetMixinKey(imgKey + subKey);
-        string currTime = DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
 
-        // 增加 wts 的內容。
-        parameters["wts"] = currTime;
+        // 加入 wts 的內容。
+        parameters["wts"] = DateTimeOffset.Now.ToUnixTimeSeconds().ToString();
 
-        // 依照 key 重排參數。
+        // 依照鍵值重新排序參數。
         parameters = parameters.OrderBy(n => n.Key).ToDictionary(n => n.Key, n => n.Value);
 
         // 過濾 value 中的 "!'()*" 字元。
@@ -59,67 +60,77 @@ public class AuthFunction
             kvp => new string(kvp.Value.Where(chr => !"!'()*".Contains(chr)).ToArray())
         );
 
-        // 序列化參數。
-        string query = new FormUrlEncodedContent(parameters).ReadAsStringAsync().Result;
+        // 序列化查詢字串參數。
+        string queryStringValue = await new FormUrlEncodedContent(parameters).ReadAsStringAsync();
 
-        // 計算 w_rid。
-        byte[] hashBytes = MD5.HashData(Encoding.UTF8.GetBytes(query + mixinKey));
+        // 計算 w_rid 的雜湊值。
+        byte[] bytesHash = MD5.HashData(Encoding.UTF8.GetBytes(queryStringValue + mixinKey));
 
-        string wbiSign = BitConverter.ToString(hashBytes).Replace("-", string.Empty).ToLower();
+        // 移除 "-" 及將字串小寫化。
+        string wRid = BitConverter.ToString(bytesHash).Replace("-", string.Empty).ToLower();
 
-        parameters["w_rid"] = wbiSign;
+        // 加入 w_rid 的內容。
+        parameters["w_rid"] = wRid;
 
         return parameters;
     }
 
     /// <summary>
-    /// 獲取最新的 img_key 和 sub_key
+    /// 取得 Wbi 的關鍵鍵值
+    /// <para>獲取最新的 img_key 和 sub_key。</para>
     /// </summary>
     /// <param name="httpClient">HttpClient</param>
     /// <returns>Task&lt;(string, string)&gt;</returns>
     private static async Task<(string, string)> GetWbiKeys(HttpClient httpClient)
     {
-        HttpResponseMessage responseMessage = await httpClient.SendAsync(new HttpRequestMessage
+        HttpRequestMessage httpRequestMessage = new()
         {
             Method = HttpMethod.Get,
             RequestUri = new Uri("https://api.bilibili.com/x/web-interface/nav"),
-        });
+        };
 
-        JsonNode response = JsonNode.Parse(await responseMessage.Content.ReadAsStringAsync())!;
+        using HttpResponseMessage? httpResponseMessage = await httpClient.SendAsync(httpRequestMessage);
 
-        string imgUrl = (string)response["data"]!["wbi_img"]!["img_url"]!;
+        string content = await httpResponseMessage.Content.ReadAsStringAsync();
 
-        imgUrl = imgUrl.Split("/")[^1].Split(".")[0];
+        JsonNode? jnContent = JsonNode.Parse(content),
+            jnImgUrl = jnContent?["data"]?["wbi_img"]?["img_url"],
+            jnSubUrl = jnContent?["data"]?["wbi_img"]?["sub_url"];
 
-        string subUrl = (string)response["data"]!["wbi_img"]!["sub_url"]!;
+        string imgUrl = jnImgUrl?.ToString() ?? string.Empty;
+        string subUrl = jnSubUrl?.ToString() ?? string.Empty;
 
-        subUrl = subUrl.Split("/")[^1].Split(".")[0];
+        if (!string.IsNullOrEmpty(imgUrl))
+        {
+            imgUrl = imgUrl.Split("/")[^1].Split(".")[0];
+        }
+
+        if (!string.IsNullOrEmpty(subUrl))
+        {
+            subUrl = subUrl.Split("/")[^1].Split(".")[0];
+        }
 
         return (imgUrl, subUrl);
     }
 
     /// <summary>
-    /// 
+    /// 取得帶有授權字串的查詢字串
     /// </summary>
-    /// <param name="httpClient"></param>
-    /// <returns></returns>
-    public static async Task<string> GetWbi(HttpClient httpClient)
+    /// <param name="httpClient">HttpClient</param>
+    /// <param name="parameters">Dictionary&lt;string, string&gt;，查詢字串參數</param>
+    /// <returns>字串</returns>
+    public static async Task<string> GetAuthQueryString(
+        HttpClient httpClient,
+        Dictionary<string, string> parameters)
     {
-        var (imgKey, subKey) = await GetWbiKeys(httpClient);
+        (string imgKey, string subKey) = await GetWbiKeys(httpClient);
 
-        Dictionary<string, string> signedParams = EncWbi(
-            parameters: new Dictionary<string, string>
-            {
-                { "foo", "114" },
-                { "bar", "514" },
-                { "baz", "1919810" }
-            },
+        Dictionary<string, string> finalParameters = await EncodeWbi(
+            parameters,
             imgKey: imgKey,
             subKey: subKey
         );
 
-        string query = await new FormUrlEncodedContent(signedParams).ReadAsStringAsync();
-
-        return query;
+        return await new FormUrlEncodedContent(finalParameters).ReadAsStringAsync();
     }
 }

--- a/BilibiliApi/Funcs/SpaceFunction.cs
+++ b/BilibiliApi/Funcs/SpaceFunction.cs
@@ -24,7 +24,14 @@ public class SpaceFunction
         HttpClient httpClient,
         string mid)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         using HttpResponseMessage response = await httpClient.GetAsync(apiUrl);
         using HttpContent content = response.Content;
@@ -52,7 +59,15 @@ public class SpaceFunction
         string mid,
         int tid)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}&tid={tid}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid },
+                { "tid", tid.ToString() }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         using HttpResponseMessage response = await httpClient.GetAsync(apiUrl);
         using HttpContent content = response.Content;
@@ -85,7 +100,17 @@ public class SpaceFunction
         int pn = 1,
         int ps = 30)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}&tid={tid}&pn={pn}&ps={ps}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid },
+                { "tid", tid.ToString() },
+                { "pn", pn.ToString() },
+                { "ps", ps.ToString() }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         using HttpResponseMessage response = await httpClient.GetAsync(apiUrl);
         using HttpContent content = response.Content;
@@ -105,11 +130,21 @@ public class SpaceFunction
     /// <summary>
     /// 取得 tlist
     /// </summary>
+    /// <param name="httpClient">HttpClient</param>
     /// <param name="mid">字串，目標使用者的 mid</param>
     /// <returns>Task&lt;ReceivedObject&lt;lTList&gt;&gt;</returns>
-    public static async Task<ReceivedObject<TList>> GetTList(string mid)
+    public static async Task<ReceivedObject<TList>> GetTListV2(
+        HttpClient httpClient,
+        string mid)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         DownloadService downloadService = DownloaderUtil
             .GetDownloadService(DownloaderUtil.GetB23DownloadConfiguration());
@@ -129,11 +164,23 @@ public class SpaceFunction
     /// <summary>
     /// 取得 page
     /// </summary>
+    /// <param name="httpClient">HttpClient</param>
     /// <param name="mid">字串，目標使用者的 mid</param>
     /// <returns>Task&lt;ReceivedObject&lt;Page&gt;&gt;</returns>
-    public static async Task<ReceivedObject<Page>> GetPage(string mid, int tid)
+    public static async Task<ReceivedObject<Page>> GetPageV2(
+        HttpClient httpClient,
+        string mid,
+        int tid)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}&tid={tid}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid },
+                { "tid", tid.ToString() }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         DownloadService downloadService = DownloaderUtil
             .GetDownloadService(DownloaderUtil.GetB23DownloadConfiguration());
@@ -153,18 +200,30 @@ public class SpaceFunction
     /// <summary>
     /// 取得 vlist
     /// </summary>
+    /// <param name="httpClient">HttpClient</param>
     /// <param name="mid">字串，目標使用者的 mid</param>
     /// <param name="tid">數值，篩選目標分區，預設值為 0</param>
     /// <param name="pn">數值，頁碼，預設值為 1 </param>
     /// <param name="ps">數值，每頁項數（最小 1 最大 50），預設值為 30</param>
     /// <returns>Task&lt;ReceivedObject&lt;List&lt;VList&gt;&gt;&gt;</returns>
-    public static async Task<ReceivedObject<List<VList>>> GetVList(
+    public static async Task<ReceivedObject<List<VList>>> GetVListV2(
+        HttpClient httpClient,
         string mid,
         int tid = 0,
         int pn = 1,
         int ps = 30)
     {
-        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?mid={mid}&tid={tid}&pn={pn}&ps={ps}";
+        string queryStringValue = await AuthFunction.GetAuthQueryString(
+            httpClient,
+            new Dictionary<string, string>()
+            {
+                { "mid", mid },
+                { "tid", tid.ToString() },
+                { "pn", pn.ToString() },
+                { "ps", ps.ToString() }
+            });
+
+        string apiUrl = $"{UrlSet.BilibiliSpaceApiUrl}?{queryStringValue}";
 
         DownloadService downloadService = DownloaderUtil
             .GetDownloadService(DownloaderUtil.GetB23DownloadConfiguration());

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,21 @@
 # 自定義工具箱更新日誌
 
+- v1.0.15
+  1. 更新 README.md。
+  2. 更新預設的使用者代理字串。（Google Chrome v115）
+  3. 將判斷字數限制的部分改為使用 StringInfo 來處理。
+  4. 加入 B 站 Wbi 驗證機制。
+  5. 更新 Downloader 函式庫至 3.0.6 版。
+  6. 更新 HtmlAgilityPack 函式庫至 1.11.50 版。
+  7. 更新 Microsoft.Playwright 函式庫至 1.36.0 版。
+  8. 更新 YoutubeDLSharp 函式庫至 1.0.0 版。
+  9. 更新 DiscordRichPresence 函式庫至 1.4.20 版。
+  10. 加入 Whisper 相關函式庫。
+  11. 加入新的預設資料夾。
+  12. 加入 FFmpeg 轉換成 WAV 檔案的相關程式碼。
+  13. 調高 Playwright 的預設等待秒數，從 1 秒調高成 2 秒。
 - v1.0.14
-  1. 更新 Microsoft.Playwright 函式庫至1.34.0 版。
+  1. 更新 Microsoft.Playwright 函式庫至 1.34.0 版。
   2. 修正 MANUAL.md 內錯誤的內容。
   3. 移除不在需要的 TODO 註解。
   4. 調整載入上一版本的設定值的相關程式碼。

--- a/Common/ExternalProgram.cs
+++ b/Common/ExternalProgram.cs
@@ -68,7 +68,9 @@ internal class ExternalProgram
                 VariableSet.DownloadsFolderPath,
                 VariableSet.ClipListsFolderPath,
                 VariableSet.LogsFolderPath,
-                VariableSet.LyricsFolderPath
+                VariableSet.LyricsFolderPath,
+                VariableSet.TempFolderPath,
+                VariableSet.ModelsFolderPath
             };
 
             foreach (string folder in folders)
@@ -641,6 +643,32 @@ internal class ExternalProgram
                 hardwareAcceleratorType,
                 deviceNo);
         }
+
+        conversion.OnDataReceived += Conversion_OnDataReceived;
+        conversion.OnProgress += Conversion_OnProgress;
+
+        return conversion;
+    }
+
+    /// <summary>
+    /// 取得加入轉換成 WAV 檔案的 IConversion
+    /// </summary>
+    /// <param name="audioStreams">IEnumerable&lt;IAudioStream&gt;</param>
+    /// <param name="outputPath">字串，輸出檔案的路徑</param>
+    /// <returns>IConversion</returns>
+    public static IConversion GetConvertToWavConversion(
+        IEnumerable<IAudioStream> audioStreams,
+        string outputPath)
+    {
+        // 轉換成取樣率為 16 kHz 的 WAV 檔案。
+        IConversion conversion = FFmpeg.Conversions.New()
+            .AddStream(audioStreams)
+            // 參考來源：https://github.com/tigros/Whisperer/blob/dcdbcd8c9b01c06016272e4a6784774768b7b316/whisperer/Form1.cs#L220
+            // TODO: 2023-03-20 需要再觀察下列參數適不適合。
+            .AddParameter("-vn -ar 16000 -ab 32k -af volume=1.75")
+            .SetOutputFormat(Format.wav)
+            .SetOutput(outputPath)
+            .SetOverwriteOutput(true);
 
         conversion.OnDataReceived += Conversion_OnDataReceived;
         conversion.OnProgress += Conversion_OnProgress;

--- a/Common/ExternalProgram.cs
+++ b/Common/ExternalProgram.cs
@@ -10,6 +10,7 @@ using Xabe.FFmpeg.Events;
 using Xabe.FFmpeg;
 using YoutubeDLSharp;
 using YoutubeDLSharp.Options;
+using System.Globalization;
 
 namespace CustomToolbox.Common;
 
@@ -758,11 +759,13 @@ internal class ExternalProgram
                 // 避免字串太長，造成顯示問題。
                 string reducedStringValue = stringValue;
 
+                StringInfo siReducedStringValue = new(reducedStringValue);
+
                 int limitLength = Properties.Settings.Default.LOperationLimitLength;
 
-                if (reducedStringValue.Length > limitLength)
+                if (siReducedStringValue.LengthInTextElements > limitLength)
                 {
-                    reducedStringValue = $"{reducedStringValue[..limitLength]}...";
+                    reducedStringValue = $"{siReducedStringValue.SubstringByTextElements(0, limitLength)}{MsgSet.Ellipses}";
                 }
 
                 _LOperation.Content = reducedStringValue;

--- a/Common/Sets/EnumSet.cs
+++ b/Common/Sets/EnumSet.cs
@@ -63,4 +63,33 @@ public class EnumSet
         NVIDIA,
         AMD
     };
+
+    /// <summary>
+    /// 抽樣策略類型
+    /// </summary>
+    public enum SamplingStrategyType
+    {
+        /// <summary>
+        /// 預設
+        /// </summary>
+        Default,
+        /// <summary>
+        /// 貪婪
+        /// </summary>
+        Greedy,
+        /// <summary>
+        /// 集束搜尋
+        /// </summary>
+        BeamSearch
+    }
+
+    /// <summary>
+    /// OpenCC 類型
+    /// </summary>
+    public enum OpenCCMode
+    {
+        None,
+        S2TWP,
+        TW2SP
+    }
 }

--- a/Common/Sets/OperationSet.cs
+++ b/Common/Sets/OperationSet.cs
@@ -971,9 +971,9 @@ internal class OperationSet
     /// <param name="ct">CancellationToken</param>
     /// <returns>Task</returns>
     public static async Task DoGenerateB23ClipList(
+        HttpClient? httpClient,
         string mid,
         bool exportJsonc = false,
-        HttpClient? httpClient = null,
         bool checkUrl = false,
         CancellationToken ct = default)
     {
@@ -981,8 +981,13 @@ internal class OperationSet
         {
             ct.ThrowIfCancellationRequested();
 
+            if (httpClient == null)
+            {
+                throw new Exception("HttpClient is null.");
+            }
+
             // 取標籤資訊。
-            ReceivedObject<TList> receivedTList = await SpaceFunction.GetTList(mid);
+            ReceivedObject<TList> receivedTList = await SpaceFunction.GetTList(httpClient, mid);
 
             if (receivedTList.Code != 0)
             {
@@ -1039,7 +1044,7 @@ internal class OperationSet
                     tidData.TID.ToString()));
 
                 // 取得分頁資訊。
-                ReceivedObject<Page> receivedPage = await SpaceFunction.GetPage(mid, tid);
+                ReceivedObject<Page> receivedPage = await SpaceFunction.GetPage(httpClient, mid, tid);
 
                 if (receivedPage.Code != 0)
                 {
@@ -1077,6 +1082,7 @@ internal class OperationSet
                         pages.ToString()));
 
                     ReceivedObject<List<VList>> receivedVLists = await SpaceFunction.GetVList(
+                        httpClient,
                         mid,
                         tid,
                         pn,

--- a/Common/Sets/OperationSet.cs
+++ b/Common/Sets/OperationSet.cs
@@ -20,6 +20,7 @@ using YoutubeDLSharp;
 using YoutubeDLSharp.Metadata;
 using YoutubeDLSharp.Options;
 using System.Net.Http;
+using System.Globalization;
 
 namespace CustomToolbox.Common.Sets;
 
@@ -1654,11 +1655,13 @@ internal class OperationSet
                 // 避免字串太長，造成顯示問題。
                 string reducedMessage = message;
 
+                StringInfo siReducedMessage = new(reducedMessage);
+
                 int limitLength = Properties.Settings.Default.LOperationLimitLength;
 
-                if (reducedMessage.Length > limitLength)
+                if (siReducedMessage.LengthInTextElements > limitLength)
                 {
-                    reducedMessage = $"{reducedMessage[..limitLength]}...";
+                    reducedMessage = $"{siReducedMessage.SubstringByTextElements(0, limitLength)}{MsgSet.Ellipses}";
                 }
 
                 _LOperation.Content = reducedMessage;

--- a/Common/Sets/VariableSet.cs
+++ b/Common/Sets/VariableSet.cs
@@ -58,6 +58,16 @@ internal class VariableSet
     public static readonly string LyricsFolderPath = Path.Combine(RootPath, "Lyrics");
 
     /// <summary>
+    /// Temp 資料夾的路徑
+    /// </summary>
+    public static readonly string TempFolderPath = Path.Combine(RootPath, "Temp");
+
+    /// <summary>
+    /// Models 資料夾的路徑
+    /// </summary>
+    public static readonly string ModelsFolderPath = Path.Combine(RootPath, "Models");
+
+    /// <summary>
     /// yt-dlp.exe 的執行檔名稱
     /// </summary>
     public static readonly string YtDlpExecName = "yt-dlp.exe";

--- a/Common/Utils/DiscordRichPresenceUtil.cs
+++ b/Common/Utils/DiscordRichPresenceUtil.cs
@@ -3,6 +3,7 @@ using CustomToolbox.Common.Sets;
 using DiscordRPC;
 using DiscordRPC.Logging;
 using DiscordRPC.Message;
+using System.Globalization;
 
 namespace CustomToolbox.Common.Utils;
 
@@ -153,7 +154,7 @@ internal class DiscordRichPresenceUtil
     public static void Dispose()
     {
         if (_GlobalDRClient != null &&
-            !_GlobalDRClient.IsDisposed) 
+            !_GlobalDRClient.IsDisposed)
         {
             _GlobalDRClient?.ClearPresence();
             _GlobalDRClient?.Dispose();
@@ -186,14 +187,16 @@ internal class DiscordRichPresenceUtil
             {
                 int magicNum = 43, maxLength = 40;
 
-                if (details.Length > magicNum)
+                StringInfo siDetails = new(details), siState = new(state);
+
+                if (siDetails.LengthInTextElements > magicNum)
                 {
-                    details = $"{details[..maxLength]}...";
+                    details = $"{siDetails.SubstringByTextElements(0, maxLength)}{MsgSet.Ellipses}";
                 }
 
-                if (state.Length > magicNum)
+                if (siState.LengthInTextElements > magicNum)
                 {
-                    state = $"{state[..maxLength]}...";
+                    state = $"{siState.SubstringByTextElements(0, maxLength)}{MsgSet.Ellipses}";
                 }
 
                 _GlobalDRClient?.SetPresence(new()

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -11,7 +11,7 @@
 	<ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
 	<ApplicationIcon>Resources\app_icon.ico</ApplicationIcon>
 	<DebugType>embedded</DebugType>
-	<Version>1.0.14</Version>
+	<Version>1.0.15</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="DiscordRichPresence" Version="1.1.4.20" />
     <PackageReference Include="Downloader" Version="3.0.6" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.50" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -20,7 +20,7 @@
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
     <PackageReference Include="Downloader" Version="3.0.6" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
@@ -29,10 +29,10 @@
     <PackageReference Include="Mpv.NET" Version="1.2.0" />
     <PackageReference Include="OpenCCNET" Version="1.0.2" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
-    <PackageReference Include="Whisper.net" Version="1.4.5" />
-    <PackageReference Include="Whisper.net.Runtime" Version="1.4.5" />
+    <PackageReference Include="Whisper.net" Version="1.4.6" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.4.6" />
     <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
-    <PackageReference Include="YoutubeDLSharp" Version="1.0.0-beta6" />
+    <PackageReference Include="YoutubeDLSharp" Version="1.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -18,13 +18,13 @@
     <PackageReference Include="AirspaceFixer" Version="1.0.6" />
     <PackageReference Include="ConsoleTableExt" Version="3.2.0" />
     <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
-    <PackageReference Include="Downloader" Version="3.0.4" />
+    <PackageReference Include="Downloader" Version="3.0.6" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
-    <PackageReference Include="HtmlAgilityPack" Version="1.11.46" />
+    <PackageReference Include="HtmlAgilityPack" Version="1.11.48" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.34.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <PackageReference Include="Mpv.NET" Version="1.2.0" />
     <PackageReference Include="OpenCCNET" Version="1.0.2" />

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -29,6 +29,8 @@
     <PackageReference Include="Mpv.NET" Version="1.2.0" />
     <PackageReference Include="OpenCCNET" Version="1.0.2" />
     <PackageReference Include="SevenZipExtractor" Version="1.0.17" />
+    <PackageReference Include="Whisper.net" Version="1.4.5" />
+    <PackageReference Include="Whisper.net.Runtime" Version="1.4.5" />
     <PackageReference Include="Xabe.FFmpeg" Version="5.2.6" />
     <PackageReference Include="YoutubeDLSharp" Version="1.0.0-beta6" />
   </ItemGroup>

--- a/CustomToolbox.csproj
+++ b/CustomToolbox.csproj
@@ -17,14 +17,14 @@
   <ItemGroup>
     <PackageReference Include="AirspaceFixer" Version="1.0.6" />
     <PackageReference Include="ConsoleTableExt" Version="3.2.0" />
-    <PackageReference Include="DiscordRichPresence" Version="1.1.3.18" />
+    <PackageReference Include="DiscordRichPresence" Version="1.1.4.20" />
     <PackageReference Include="Downloader" Version="3.0.6" />
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.0.108" />
     <PackageReference Include="HtmlAgilityPack" Version="1.11.49" />
     <PackageReference Include="Humanizer" Version="2.14.1" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="7.0.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="7.0.0" />
-    <PackageReference Include="Microsoft.Playwright" Version="1.35.0" />
+    <PackageReference Include="Microsoft.Playwright" Version="1.36.0" />
     <PackageReference Include="ModernWpfUI" Version="0.9.6" />
     <PackageReference Include="Mpv.NET" Version="1.2.0" />
     <PackageReference Include="OpenCCNET" Version="1.0.2" />

--- a/MpvPlayer.Methods.cs
+++ b/MpvPlayer.Methods.cs
@@ -11,6 +11,7 @@ using Mpv.NET.API;
 using Mpv.NET.Player;
 using System.ComponentModel;
 using System.Security.Cryptography;
+using System.Globalization;
 
 namespace CustomToolbox;
 
@@ -414,10 +415,12 @@ public partial class WMain
             {
                 if (CPPlayer.Status != ClipPlayerStatus.Paused)
                 {
+                    StringInfo siClipTitle = new(clipData.Name ?? string.Empty);
+
                     string clipTitle = string.IsNullOrEmpty(clipData.Name) ?
                         MsgSet.ClipTitle :
-                        (clipData.Name.Length > 40 ?
-                            $"{clipData.Name[..40]}{MsgSet.Ellipses}" :
+                        (siClipTitle.LengthInTextElements > 40 ?
+                            $"{siClipTitle.SubstringByTextElements(0, 40)}{MsgSet.Ellipses}" :
                             clipData.Name);
 
                     LClipTitle.Content = clipTitle;

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -235,7 +235,7 @@ namespace CustomToolbox.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/114.0.0.0 Safari/537.36")]
+            "Chrome/115.0.0.0 Safari/537.36")]
         public string UserAgent {
             get {
                 return ((string)(this["UserAgent"]));
@@ -622,7 +622,8 @@ namespace CustomToolbox.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"")]
+        [global::System.Configuration.DefaultSettingValueAttribute("\"Not/A)Brand\";v=\"99.0.0.0\", \"Google Chrome\";v=\"115.0.5790.99\", \"Chromium\";v=\"115." +
+            "0.5790.99\"")]
         public string SecChUa {
             get {
                 return ((string)(this["SecChUa"]));

--- a/Properties/Settings.Designer.cs
+++ b/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace CustomToolbox.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.5.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));
@@ -235,7 +235,7 @@ namespace CustomToolbox.Properties {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) " +
-            "Chrome/113.0.0.0 Safari/537.36")]
+            "Chrome/114.0.0.0 Safari/537.36")]
         public string UserAgent {
             get {
                 return ((string)(this["UserAgent"]));
@@ -523,7 +523,7 @@ namespace CustomToolbox.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("1000")]
+        [global::System.Configuration.DefaultSettingValueAttribute("2000")]
         public int PlaywrightSleepMs {
             get {
                 return ((int)(this["PlaywrightSleepMs"]));
@@ -622,7 +622,7 @@ namespace CustomToolbox.Properties {
         
         [global::System.Configuration.ApplicationScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("\"Google Chrome\";v=\"113\", \"Chromium\";v=\"113\", \"Not-A.Brand\";v=\"24\"")]
+        [global::System.Configuration.DefaultSettingValueAttribute("\"Not.A/Brand\";v=\"8\", \"Chromium\";v=\"114\", \"Google Chrome\";v=\"114\"")]
         public string SecChUa {
             get {
                 return ((string)(this["SecChUa"]));

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -57,7 +57,7 @@
       <Value Profile="(Default)">10</Value>
     </Setting>
     <Setting Name="UserAgent" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</Value>
+      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36</Value>
     </Setting>
     <Setting Name="RDGContentRow1Height" Type="System.Windows.GridLength" Scope="User">
       <Value Profile="(Default)">2*</Value>
@@ -165,7 +165,7 @@
       <Value Profile="(Default)">1.36.0</Value>
     </Setting>
     <Setting Name="SecChUa" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"</Value>
+      <Value Profile="(Default)">"Not/A)Brand";v="99.0.0.0", "Google Chrome";v="115.0.5790.99", "Chromium";v="115.0.5790.99"</Value>
     </Setting>
     <Setting Name="SecChUaMobile" Type="System.String" Scope="Application">
       <Value Profile="(Default)">?0</Value>

--- a/Properties/Settings.settings
+++ b/Properties/Settings.settings
@@ -57,7 +57,7 @@
       <Value Profile="(Default)">10</Value>
     </Setting>
     <Setting Name="UserAgent" Type="System.String" Scope="User">
-      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/113.0.0.0 Safari/537.36</Value>
+      <Value Profile="(Default)">Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/114.0.0.0 Safari/537.36</Value>
     </Setting>
     <Setting Name="RDGContentRow1Height" Type="System.Windows.GridLength" Scope="User">
       <Value Profile="(Default)">2*</Value>
@@ -135,7 +135,7 @@
       <Value Profile="(Default)">30000</Value>
     </Setting>
     <Setting Name="PlaywrightSleepMs" Type="System.Int32" Scope="Application">
-      <Value Profile="(Default)">1000</Value>
+      <Value Profile="(Default)">2000</Value>
     </Setting>
     <Setting Name="PlaywrightDevSleepMs" Type="System.Int32" Scope="Application">
       <Value Profile="(Default)">120000</Value>
@@ -165,7 +165,7 @@
       <Value Profile="(Default)">1.36.0</Value>
     </Setting>
     <Setting Name="SecChUa" Type="System.String" Scope="Application">
-      <Value Profile="(Default)">"Google Chrome";v="113", "Chromium";v="113", "Not-A.Brand";v="24"</Value>
+      <Value Profile="(Default)">"Not.A/Brand";v="8", "Chromium";v="114", "Google Chrome";v="114"</Value>
     </Setting>
     <Setting Name="SecChUaMobile" Type="System.String" Scope="Application">
       <Value Profile="(Default)">?0</Value>

--- a/README.md
+++ b/README.md
@@ -26,24 +26,7 @@
 - [更新日誌](CHANGELOG.md)
 - [使用手冊](MANUAL.md)
 
-## 三、使用的函式庫
-
-- [adoconnection/SevenZipExtractor](https://github.com/adoconnection/SevenZipExtractor)
-- [bezzad/Downloader](https://github.com/bezzad/Downloader)
-- [Bluegrams/YoutubeDLSharp](https://github.com/Bluegrams/YoutubeDLSharp)
-- [chris84948/AirspaceFixer](https://github.com/chris84948/AirspaceFixer)
-- [CosineG/OpenCC.NET](https://github.com/CosineG/OpenCC.NET)
-- [HavenDV/H.NotifyIcon](https://github.com/HavenDV/H.NotifyIcon)
-- [hudec117/Mpv.NET-lib-](https://github.com/hudec117/Mpv.NET-lib-)
-- [Humanizr/Humanizer](https://github.com/Humanizr/Humanizer)
-- [Kinnara/ModernWpf](https://github.com/Kinnara/ModernWpf)
-- [Lachee/discord-rpc-csharp](https://github.com/Lachee/discord-rpc-csharp)
-- [microsoft/playwright-dotnet](https://github.com/microsoft/playwright-dotnet)
-- [minhhungit/ConsoleTableExt](https://github.com/minhhungit/ConsoleTableExt)
-- [tomaszzmuda/Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg)
-- [zzzprojects/html-agility-pack](https://github.com/zzzprojects/html-agility-pack)
-
-## 四、相依性檔案
+## 三、相依性檔案
 
 - [aria2/aria2](https://github.com/aria2/aria2)
 - [libmpv](https://sourceforge.net/projects/mpv-player-windows/files/libmpv/)
@@ -51,13 +34,65 @@
 - [sub_charenc_parameters.txt](https://trac.ffmpeg.org/attachment/ticket/2431/sub_charenc_parameters.txt)
 - [yt-dlp/FFmpeg-Builds](https://github.com/yt-dlp/FFmpeg-Builds)
 - [yt-dlp/yt-dlp](https://github.com/yt-dlp/yt-dlp)
-- [ytdl_jook.lua](https://github.com/mpv-player/mpv/blob/master/player/lua/ytdl_hook.lua)
+- [ytdl_hook.lua](https://github.com/mpv-player/mpv/blob/master/player/lua/ytdl_hook.lua)
 
-## 五、網路資源
+## 四、網路資源
 
 - [rubujo/CustomPlaylist](https://github.com/rubujo/CustomPlaylist)
 - [YoutubeClipPlaylist/Lyrics](https://github.com/YoutubeClipPlaylist/Lyrics)
 - [YoutubeClipPlaylist/Playlists](https://github.com/YoutubeClipPlaylist/Playlists)
+
+## 五、授權資訊
+
+- [adoconnection/SevenZipExtractor](https://github.com/adoconnection/SevenZipExtractor)
+   - Copyright (c) 2017 Alexander Selishchev
+   - [MIT 授權條款](https://github.com/adoconnection/SevenZipExtractor/blob/master/LICENSE)
+- [bezzad/Downloader](https://github.com/bezzad/Downloader)
+   - Copyright (c) 2021 Behzad Khosravifar
+   - [MIT 授權條款](https://github.com/bezzad/Downloader/blob/master/LICENSE)
+- [Bluegrams/YoutubeDLSharp](https://github.com/Bluegrams/YoutubeDLSharp)
+   - Copyright (c) 2020-2022, Bluegrams. All rights reserved.
+   - [BSD 三句版授權條款](https://github.com/Bluegrams/YoutubeDLSharp/blob/master/LICENSE.txt)
+- [chris84948/AirspaceFixer](https://github.com/chris84948/AirspaceFixer)
+   - Copyright (c) 2017 chris84948
+   - [MIT 授權條款](https://github.com/chris84948/AirspaceFixer/blob/master/LICENSE)
+- [CosineG/OpenCC.NET](https://github.com/CosineG/OpenCC.NET)
+   - [Apache 授權條款版本 2](https://github.com/CosineG/OpenCC.NET/blob/master/LICENSE)
+- [HavenDV/H.NotifyIcon](https://github.com/HavenDV/H.NotifyIcon)
+   - Copyright (c) 2020 havendv
+   - [MIT 授權條款](https://github.com/HavenDV/H.NotifyIcon/blob/master/LICENSE.md)
+- [hudec117/Mpv.NET-lib-](https://github.com/hudec117/Mpv.NET-lib-)
+   - Copyright (c) 2019 Aurel Hudec Jr
+   - [MIT 授權條款](https://github.com/hudec117/Mpv.NET-lib-/blob/master/LICENSE)
+- [Humanizr/Humanizer](https://github.com/Humanizr/Humanizer)
+   - Copyright (c) .NET Foundation and Contributors
+   - [MIT 授權條款](https://github.com/Humanizr/Humanizer/blob/main/LICENSE)
+- [Kinnara/ModernWpf](https://github.com/Kinnara/ModernWpf)
+   - Copyright (c) 2019 Yimeng Wu
+   - [MIT 授權條款](https://github.com/Kinnara/ModernWpf/blob/master/LICENSE)
+- [Lachee/discord-rpc-csharp](https://github.com/Lachee/discord-rpc-csharp)
+   - Copyright (c) 2021 Lachee
+   - [MIT 授權條款](https://github.com/Lachee/discord-rpc-csharp/blob/master/LICENSE)
+- [microsoft/playwright-dotnet](https://github.com/microsoft/playwright-dotnet)
+   - Copyright (c) 2020 Darío Kondratiuk
+   - [MIT 授權條款](https://github.com/microsoft/playwright-dotnet/blob/main/LICENSE)
+- [minhhungit/ConsoleTableExt](https://github.com/minhhungit/ConsoleTableExt)
+   - Copyright (c) 2017 Jin
+   - [MIT 授權條款](https://github.com/minhhungit/ConsoleTableExt/blob/master/LICENSE)
+- [tomaszzmuda/Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg)
+   - [授權合約](https://ffmpeg.xabe.net/license.html)
+- [zzzprojects/html-agility-pack](https://github.com/zzzprojects/html-agility-pack)
+   - [MIT 授權條款](https://github.com/zzzprojects/html-agility-pack/blob/master/LICENSE)
+- [FFmpeg](https://ffmpeg.org/)
+   - [FFmpeg 授權條款和法律方面的注意事項](https://ffmpeg.org/legal.html)
+- [ggerganov/whisper.cpp](https://github.com/ggerganov/whisper.cpp)
+   - Copyright (c) 2023  Georgi Gerganov
+   - [MIT 授權條款](https://github.com/ggerganov/whisper.cpp/blob/master/LICENSE)
+- [sandrohanea/whisper.net](https://github.com/sandrohanea/whisper.net)
+   - Copyright (c) 2023 sandrohanea
+   - [MIT 授權條款](https://github.com/sandrohanea/whisper.net/blob/main/LICENSE)
+
+因 [Xabe.FFmpeg](https://github.com/tomaszzmuda/Xabe.FFmpeg) 函式庫[授權合約](https://ffmpeg.xabe.net/license.html)的限制，此 GitHub 倉庫內，`沒有標註來源`的內容，皆採用 [CC BY-NC-SA 3.0](https://creativecommons.org/licenses/by-nc-sa/3.0/) 授權條款釋出，反之皆以其來源之授權條款為準。
 
 ## 六、注意事項
 

--- a/TINetResource.Events.cs
+++ b/TINetResource.Events.cs
@@ -7,6 +7,7 @@ using CustomToolbox.Common.Sets;
 using CustomToolbox.Common.Utils;
 using System.Windows;
 using System.Windows.Controls;
+using System.Net.Http;
 using TextBox = System.Windows.Controls.TextBox;
 
 namespace CustomToolbox;
@@ -237,9 +238,9 @@ public partial class WMain
                 }
 
                 await OperationSet.DoGenerateB23ClipList(
+                    GetHttpClient(),
                     TBB23UserMID.Text,
                     CBB23ClipListExportJsonc.IsChecked ?? false,
-                    GetHttpClient(),
                     CBB23ClipListCheckUrl.IsChecked ?? false,
                     GetGlobalCT());
 

--- a/WMain.Methods.cs
+++ b/WMain.Methods.cs
@@ -672,7 +672,7 @@ public partial class WMain
     /// 取得 HttpClient
     /// </summary>
     /// <returns>HttpClient</returns>
-    public HttpClient? GetHttpClient()
+    public static HttpClient? GetHttpClient()
     {
         HttpClient? httpClient = GlobalHCFactory?.CreateClient();
 


### PR DESCRIPTION
1. 更新 README.md。
2. 更新預設的使用者代理字串。（Google Chrome v115）
3. 將判斷字數限制的部分改為使用 StringInfo 來處理。
4. 加入 B 站 Wbi 驗證機制。
5. 更新 Downloader 函式庫至 3.0.6 版。
6. 更新 HtmlAgilityPack 函式庫至 1.11.50 版。
7. 更新 Microsoft.Playwright 函式庫至 1.36.0 版。
8. 更新 YoutubeDLSharp 函式庫至 1.0.0 版。
9. 更新 DiscordRichPresence 函式庫至 1.4.20 版。
10. 加入 Whisper 相關函式庫。
11. 加入新的預設資料夾。
12. 加入 FFmpeg 轉換成 WAV 檔案的相關程式碼。
13. 調高 Playwright 的預設等待秒數，從 1 秒調高成 2 秒。